### PR TITLE
Load Supabase config from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment configuration
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_PUBLISHABLE_KEY=your-publishable-key

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -3,8 +3,12 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://rwxjdyudnkkehdjdcbtc.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJ3eGpkeXVkbmtrZWhkamRjYnRjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDI0MDk1MjksImV4cCI6MjA1Nzk4NTUyOX0.mwGzGBpq2Idv8mRUPH-kAYrFUPptcDf2nbNJ50oNpbQ";
+const SUPABASE_URL =
+  (import.meta as any).env.SUPABASE_URL ?? process.env.SUPABASE_URL ?? '';
+const SUPABASE_PUBLISHABLE_KEY =
+  (import.meta as any).env.SUPABASE_PUBLISHABLE_KEY ??
+  process.env.SUPABASE_PUBLISHABLE_KEY ??
+  '';
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  envPrefix: ["VITE_", "SUPABASE_"],
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- read Supabase credentials from environment variables
- expose SUPABASE_ variables via Vite config
- document variables in `.env.example`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*