### PR TITLE
Remove leftover gptengineer script

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,6 @@
     <!-- Google AdSense -->
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3372507393637890"
      crossorigin="anonymous"></script>
-    <!-- IMPORTANT: GPT Engineer script is required for proper module loading -->
-    <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
   </head>
 
   <body>

--- a/src/components/SecurityHeaders.tsx
+++ b/src/components/SecurityHeaders.tsx
@@ -6,7 +6,7 @@ export function SecurityHeaders() {
     // Apply CSP headers via meta tag since we can't modify HTTP headers directly in a client-side app
     const cspContent = [
       "default-src 'self'",
-      "script-src 'self' https://cdn.gpteng.co https://pagead2.googlesyndication.com 'unsafe-inline'", // Allow necessary scripts
+      "script-src 'self' https://pagead2.googlesyndication.com 'unsafe-inline'", // Allow necessary scripts
       "style-src 'self' https://fonts.googleapis.com 'unsafe-inline'",
       "img-src 'self' data: https: blob:",
       "font-src 'self' https://fonts.gstatic.com",


### PR DESCRIPTION
## Summary
- remove the gptengineer script tag from `index.html`
- update CSP in `SecurityHeaders` to no longer allow cdn.gpteng.co

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*